### PR TITLE
Set docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,9 @@ RUN mkdir build && \
              -DCMAKE_CXX_FLAGS="-Wno-error=conversion" && \
     make solc -j$(nproc)
 
+FROM ubuntu:jammy-20240212
+
+COPY --from=solc-builder /app/solidity/build/solc/solc /app/solc
 WORKDIR /app/root
-ENTRYPOINT ["/app/solidity/build/solc/solc"]
+
+ENTRYPOINT ["/app/solc"]

--- a/eof-solc
+++ b/eof-solc
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run -i -v $(pwd):/app/root eof-solc  "$@"
+docker run --rm -i -v $(pwd):/app/root ghcr.io/paradigmxyz/forge-eof:latest  "$@"


### PR DESCRIPTION
Updates dockerfile to make image lighter and sets correct image in `eof-solc`. Currently set to latest to make CI pass, will create follow-up to update it to concrete one once its built and published